### PR TITLE
chore(*) add pull.yml for automated rebase configuration

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,10 @@
+version: "1"
+rules:
+  - base: main
+    upstream: proxy-wasm:main
+    mergeMethod: rebase
+    mergeUnstable: false
+    conflictReviewers:
+      - casimiro
+      - thibaultcha
+conflictLabel: "rebase-conflict"


### PR DESCRIPTION
This fork will probably not be used, but if the need arises we want to ensure we have the latest upstream code.